### PR TITLE
string compare

### DIFF
--- a/mdns.c
+++ b/mdns.c
@@ -154,15 +154,19 @@ service_callback(int sock, const struct sockaddr* from, size_t addrlen,
 		printf("%.*s : question PTR %.*s\n",
 		       MDNS_STRING_FORMAT(fromaddrstr), MDNS_STRING_FORMAT(service));
 
+        char *service_str = (char *)malloc(service.length + 1);
+        service_str[service.length] = '\0';
+        strncpy(service_str, service.str, service.length);
+
 		const char dns_sd[] = "_services._dns-sd._udp.local.";
 		const service_record_t* service_record = (const service_record_t*)user_data;
 		size_t service_length = strlen(service_record->service);
-		if ((service.length == (sizeof(dns_sd) - 1)) && (strcmp(service.str, dns_sd) == 0)) {
+		if ((service.length == (sizeof(dns_sd) - 1)) && (strcmp(service_str, dns_sd) == 0)) {
 			printf("  --> answer %s\n", service_record->service);
 			mdns_discovery_answer(sock, from, addrlen, sendbuffer,
                                   sizeof(sendbuffer), service_record->service, service_length);
 		}
-		else if ((service.length == service_length) && (strcmp(service.str, service_record->service) == 0)) {
+		else if ((service.length == service_length) && (strcmp(service_str, service_record->service) == 0)) {
 			printf("  --> answer %s.%s port %d\n", service_record->hostname, service_record->service, service_record->port);
 			mdns_query_answer(sock, from, addrlen, sendbuffer, sizeof(sendbuffer),
 			                  transaction_id, service_record->service, service_length,

--- a/mdns.c
+++ b/mdns.c
@@ -174,6 +174,8 @@ service_callback(int sock, const struct sockaddr* from, size_t addrlen,
 							  service_record->address_ipv4, service_record->address_ipv6,
 			                  (uint16_t)service_record->port, 0, 0);
 		}
+
+        free(service_str);
 	}
 	return 0;
 }


### PR DESCRIPTION
In order to answer correctly,The suffix of string should be discard.

For example,the actually string of mdns query may be **"_services._dns-sd._udp.local.n-addr.arpa."**