### PR TITLE
build: add cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,66 @@
+cmake_minimum_required(VERSION 3.11)
+project(mdns VERSION 1.0.0)
+
+option(MDNS_BUILD_EXAMPLE "build example" ON)
+
+# Set the output of the libraries and executables.
+set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)
+set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
+
+# ##############################################################################
+# library
+# ##############################################################################
+
+add_library(${PROJECT_NAME} INTERFACE)
+target_include_directories(
+  ${PROJECT_NAME} INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/>
+                            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+if(WIN32)
+  target_link_libraries(${PROJECT_NAME} INTERFACE iphlpapi ws2_32)
+endif()
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+
+# ##############################################################################
+# example
+# ##############################################################################
+
+if(MDNS_BUILD_EXAMPLE)
+  add_executable(${PROJECT_NAME}_example mdns.c)
+  target_link_libraries(${PROJECT_NAME}_example ${PROJECT_NAME})
+endif()
+
+# ##############################################################################
+# install
+# ##############################################################################
+
+include(GNUInstallDirs)
+
+install(
+  TARGETS ${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}_Targets
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+  "${PROJECT_NAME}ConfigVersion.cmake"
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY SameMajorVersion)
+
+configure_package_config_file(
+  "${PROJECT_SOURCE_DIR}/cmake/Config.cmake.in"
+  "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake" INSTALL_DESTINATION
+  ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake)
+
+install(
+  EXPORT ${PROJECT_NAME}_Targets
+  FILE ${PROJECT_NAME}Targets.cmake
+  NAMESPACE ${PROJECT_NAME}::
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake)
+
+install(FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+              "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake)
+
+install(FILES "${PROJECT_SOURCE_DIR}/mdns.h" DESTINATION include)

--- a/README.md
+++ b/README.md
@@ -67,3 +67,8 @@ The `mdns.c` file contains a test executable implementation using the library to
 
 #### clang
 `clang -o mdns mdns.c`
+
+## Using with cmake or conan
+
+* use cmake with `FetchContent` or install and `find_package`
+* use conan with dependency name `mdns/20200130`, and `find_package` -> https://conan.io/center/mdns/20200130

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+check_required_components("@PROJECT_NAME@")


### PR DESCRIPTION
# what: 
basically this adds cmake support to be able to add this and do `add_subdirectory`, `find_package` etc.

# why:
by having this upstream, we make it easier to users of this lib. otherwise everyone will create his cmake wrapper scripts