### PR TITLE
feat: add extern c to header file

### DIFF
--- a/mdns.h
+++ b/mdns.h
@@ -29,6 +29,10 @@
 #include <netinet/in.h>
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define MDNS_INVALID_POS ((size_t)-1)
 
 #define MDNS_STRING_CONST(s) (s), (sizeof((s))-1)
@@ -1166,4 +1170,8 @@ mdns_record_parse_txt(const void* buffer, size_t size, size_t offset, size_t len
 
 #ifdef _WIN32
 #undef strncasecmp
+#endif
+
+#ifdef __cplusplus
+}
 #endif


### PR DESCRIPTION
# what 
adds `extern "C"` to allow C code in cpp 

# why

when using the `mdns.h` file in cpp source code: 
```
/home/ladmin/.conan/data/mdns/20200130/_/_/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/include/mdns.h:362:26: error: invalid conversion from ‘const void*’ to ‘const uint8_t*’ {aka ‘const unsigned char*’} [-fpermissive]
  362 |  const uint8_t* buffer = rawdata;
      |                          ^~~~~~~
      |                          |
      |                          const void*
```
