### PR TITLE
feat: add possibility to stop service announcement

### DIFF
--- a/mdns.c
+++ b/mdns.c
@@ -909,6 +909,23 @@ service_mdns(const char* hostname, const char* service_name, int service_port) {
 		}
 	}
 
+	// Send a goodbye on end of service
+	{
+		mdns_record_t additional[5] = {0};
+		size_t additional_count = 0;
+		additional[additional_count++] = service.record_srv;
+		if (service.address_ipv4.sin_family == AF_INET)
+			additional[additional_count++] = service.record_a;
+		if (service.address_ipv6.sin6_family == AF_INET6)
+			additional[additional_count++] = service.record_aaaa;
+		additional[additional_count++] = service.txt_record[0];
+		additional[additional_count++] = service.txt_record[1];
+
+		for (int isock = 0; isock < num_sockets; ++isock)
+			mdns_goodbye_multicast(sockets[isock], buffer, capacity, service.record_ptr, 0, 0,
+			                        additional, additional_count);
+	}
+
 	free(buffer);
 	free(service_name_buffer);
 

--- a/mdns.h
+++ b/mdns.h
@@ -271,7 +271,14 @@ mdns_announce_multicast(int sock, void* buffer, size_t capacity, mdns_record_t a
                         mdns_record_t* authority, size_t authority_count, mdns_record_t* additional,
                         size_t additional_count);
 
-// Parse records functions
+//! Send a variable multicast mDNS announcement. Use this on service end for removing the resource
+//! from the local network. The records must be identical to the according announcement.
+static int
+mdns_goodbye_multicast(int sock, void* buffer, size_t capacity, mdns_record_t answer,
+                       mdns_record_t* authority, size_t authority_count, mdns_record_t* additional,
+                       size_t additional_count);
+
+    // Parse records functions
 
 //! Parse a PTR record, returns the name in the record
 static mdns_string_t

--- a/mdns.h
+++ b/mdns.h
@@ -1336,14 +1336,13 @@ mdns_query_answer_unicast(int sock, const void* address, size_t address_size, vo
 	return mdns_unicast_send(sock, address, address_size, buffer, tosend);
 }
 
+
 static int
-mdns_answer_multicast_rclass(int sock, void* buffer, size_t capacity, uint16_t rclass,
+mdns_answer_multicast_rclass_ttl(int sock, void* buffer, size_t capacity, uint16_t rclass,
                              mdns_record_t answer, mdns_record_t* authority, size_t authority_count,
-                             mdns_record_t* additional, size_t additional_count) {
+                             mdns_record_t* additional, size_t additional_count, uint32_t ttl) {
 	if (capacity < (sizeof(struct mdns_header_t) + 32 + 4))
 		return -1;
-
-	uint32_t ttl = 60;
 
 	// Basic answer structure
 	struct mdns_header_t* header = (struct mdns_header_t*)buffer;
@@ -1381,6 +1380,14 @@ mdns_answer_multicast_rclass(int sock, void* buffer, size_t capacity, uint16_t r
 }
 
 static int
+mdns_answer_multicast_rclass(int sock, void* buffer, size_t capacity, uint16_t rclass,
+                             mdns_record_t answer, mdns_record_t* authority, size_t authority_count,
+                             mdns_record_t* additional, size_t additional_count) {
+	return mdns_answer_multicast_rclass_ttl(sock, buffer, capacity, rclass, answer, authority,
+	                                        authority_count, additional, additional_count, 60);
+}
+
+static int
 mdns_query_answer_multicast(int sock, void* buffer, size_t capacity, mdns_record_t answer,
                             mdns_record_t* authority, size_t authority_count,
                             mdns_record_t* additional, size_t additional_count) {
@@ -1396,6 +1403,15 @@ mdns_announce_multicast(int sock, void* buffer, size_t capacity, mdns_record_t a
 	uint16_t rclass = MDNS_CLASS_IN | MDNS_CACHE_FLUSH;
 	return mdns_answer_multicast_rclass(sock, buffer, capacity, rclass, answer, authority,
 	                                    authority_count, additional, additional_count);
+}
+
+static int
+mdns_goodbye_multicast(int sock, void* buffer, size_t capacity, mdns_record_t answer,
+                        mdns_record_t* authority, size_t authority_count, mdns_record_t* additional,
+                        size_t additional_count) {
+	uint16_t rclass = MDNS_CLASS_IN | MDNS_CACHE_FLUSH;
+	return mdns_answer_multicast_rclass_ttl(sock, buffer, capacity, rclass, answer, authority,
+	                                    authority_count, additional, additional_count, 0);
 }
 
 static mdns_string_t

--- a/mdns.h
+++ b/mdns.h
@@ -278,7 +278,7 @@ mdns_goodbye_multicast(int sock, void* buffer, size_t capacity, mdns_record_t an
                        mdns_record_t* authority, size_t authority_count, mdns_record_t* additional,
                        size_t additional_count);
 
-    // Parse records functions
+// Parse records functions
 
 //! Parse a PTR record, returns the name in the record
 static mdns_string_t


### PR DESCRIPTION
According to [rfc6762](https://datatracker.ietf.org/doc/html/rfc6762#section-10.1) Section 10.1 a service can inform listeners that the ressouce will be removed by sending a multicast packet with ttl timeout 0.