### PR TITLE
fix MultiDevice server use one servername such as _abc._tcp, new devi…

### DIFF
--- a/mdns.c
+++ b/mdns.c
@@ -711,7 +711,7 @@ send_mdns_query(const char* service, int record) {
 		printf("Failed to open any client sockets\n");
 		return -1;
 	}
-	printf("Opened %d socket%s for mDNS query\n", num_sockets, num_sockets ? "s" : "");
+	printf("Opened %d socket%s for mDNS query\n", num_sockets, num_sockets > 1 ? "s" : "");
 
 	size_t capacity = 2048;
 	void* buffer = malloc(capacity);
@@ -784,7 +784,7 @@ service_mdns(const char* hostname, const char* service_name, int service_port) {
 		printf("Failed to open any client sockets\n");
 		return -1;
 	}
-	printf("Opened %d socket%s for mDNS service\n", num_sockets, num_sockets ? "s" : "");
+	printf("Opened %d socket%s for mDNS service\n", num_sockets, num_sockets > 1 ? "s" : "");
 
 	size_t service_name_length = strlen(service_name);
 	if (!service_name_length) {

--- a/mdns.h
+++ b/mdns.h
@@ -1411,7 +1411,7 @@ static int
 mdns_announce_multicast(int sock, void* buffer, size_t capacity, mdns_record_t answer,
                         mdns_record_t* authority, size_t authority_count, mdns_record_t* additional,
                         size_t additional_count) {
-	uint16_t rclass = MDNS_CLASS_IN | MDNS_CACHE_FLUSH;
+	uint16_t rclass = MDNS_CLASS_IN /*| MDNS_CACHE_FLUSH*/;
 	return mdns_answer_multicast_rclass(sock, buffer, capacity, rclass, answer, authority,
 	                                    authority_count, additional, additional_count);
 }
@@ -1420,7 +1420,7 @@ static int
 mdns_goodbye_multicast(int sock, void* buffer, size_t capacity, mdns_record_t answer,
                         mdns_record_t* authority, size_t authority_count, mdns_record_t* additional,
                         size_t additional_count) {
-	uint16_t rclass = MDNS_CLASS_IN | MDNS_CACHE_FLUSH;
+	uint16_t rclass = MDNS_CLASS_IN /*| MDNS_CACHE_FLUSH*/;
 	return mdns_answer_multicast_rclass_ttl(sock, buffer, capacity, rclass, answer, authority,
 	                                    authority_count, additional, additional_count, 0);
 }


### PR DESCRIPTION
when I use MDNS_CACHE_FLUSH flag in my mdns service , my new device can replace the older device,and make it lost in android NsdManager，I think don't use it will be better.

my NsdManager log:
D/[mdns start]: _jxmirror._tcp.
D/[mdns get info]: Desktop-Test-123456789-测试-abcdefg-END
D/[mdns lost info]: Desktop-Test-123456789-测试-abcdefg-END
D/[mdns get info]: noName

If don't use MDNS_CACHE_FLUSH my log:
D/[mdns start]: _jxmirror._tcp.
D/[mdns get info]: Desktop-Test-123456789-测试-abcdefg-END
W/om.rom1v.sndcp: Accessing hidden method Lmiui/contentcatcher/sdk/ContentCatcherManager;->unregisterContentInjector(Lmiui/contentcatcher/sdk/Token;)V (greylist, linking, allowed)
D/[mdns get info]: noName