### PR TITLE
parse boolean txt records (keys without value) correctly

### DIFF
--- a/mdns.h
+++ b/mdns.h
@@ -1572,7 +1572,7 @@ mdns_record_parse_txt(const void* buffer, size_t size, size_t offset, size_t len
 		++strdata;
 		offset += sublength + 1;
 
-		size_t separator = 0;
+		size_t separator = sublength;
 		for (size_t c = 0; c < sublength; ++c) {
 			// DNS-SD TXT record keys MUST be printable US-ASCII, [0x20, 0x7E]
 			if ((strdata[c] < 0x20) || (strdata[c] > 0x7E))
@@ -1582,9 +1582,6 @@ mdns_record_parse_txt(const void* buffer, size_t size, size_t offset, size_t len
 				break;
 			}
 		}
-
-		if (!separator)
-			continue;
 
 		if (separator < sublength) {
 			records[parsed].key.str = strdata;

--- a/mdns.h
+++ b/mdns.h
@@ -1575,13 +1575,18 @@ mdns_record_parse_txt(const void* buffer, size_t size, size_t offset, size_t len
 		size_t separator = sublength;
 		for (size_t c = 0; c < sublength; ++c) {
 			// DNS-SD TXT record keys MUST be printable US-ASCII, [0x20, 0x7E]
-			if ((strdata[c] < 0x20) || (strdata[c] > 0x7E))
+			if ((strdata[c] < 0x20) || (strdata[c] > 0x7E)) {
+				separator = 0;
 				break;
+			}
 			if (strdata[c] == '=') {
 				separator = c;
 				break;
 			}
 		}
+
+		if (!separator)
+			continue;
 
 		if (separator < sublength) {
 			records[parsed].key.str = strdata;


### PR DESCRIPTION
Hey :) While playing around with your mdns library i noticed that txt records containing no values weren't parsed correctly. The problem is that they are discarded if no separator ('=') has been found yet, though the entry is completely reasonable. I provided a small fix for this issue and it would be great if you merge it into the main branch :)
Have a great weekend!