### PR TITLE
mdns.c: Fix mdns_query_recv() return storage type

### DIFF
--- a/mdns.c
+++ b/mdns.c
@@ -817,8 +817,8 @@ send_mdns_query(mdns_query_t* query, size_t count) {
 		if (res > 0) {
 			for (int isock = 0; isock < num_sockets; ++isock) {
 				if (FD_ISSET(sockets[isock], &readfs)) {
-					int rec = mdns_query_recv(sockets[isock], buffer, capacity, query_callback,
-					                          user_data, query_id[isock]);
+					size_t rec = mdns_query_recv(sockets[isock], buffer, capacity, query_callback,
+					                             user_data, query_id[isock]);
 					if (rec > 0)
 						records += rec;
 				}


### PR DESCRIPTION
This is done to avoid the following warning:
`mdns.c:820:16: Implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'int'`