### PR TITLE
Set language and standard (CMake).

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: Continuous Integration
+
+on:
+  workflow_dispatch:
+  push:
+    paths-ignore:
+      - 'README.md'
+
+jobs:
+  build-and-test:
+    name: Build and test
+
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [ Release, Debug ]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Configure
+      run: cmake -B _build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+
+    - name: Build
+      run: cmake --build _build --config ${{ matrix.build_type }}
+
+    - name: Test
+      run: ctest --output-on-failure --test-dir _build --build-config ${{ matrix.build_type }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.0)
-project(mdns VERSION 1.2.0)
+project(mdns VERSION 1.2.0 LANGUAGES C)
 
 option(MDNS_BUILD_EXAMPLE "build example" ON)
 
@@ -19,6 +19,7 @@ if(WIN32)
   target_link_libraries(${PROJECT_NAME} INTERFACE iphlpapi ws2_32)
 endif()
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+target_compile_features(${PROJECT_NAME} INTERFACE c_std_99)
 
 # ##############################################################################
 # example


### PR DESCRIPTION
- Set language to C to exclude C++ from CMake initialization.
- Set standard to C99 to fix following: `error: ‘for’ loop initial declarations are only allowed in C99 mode`