### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: Continuous Integration
+
+on:
+  workflow_dispatch:
+  push:
+    paths-ignore:
+      - 'README.md'
+      - 'LICENSE'
+      - 'CHANGELOG'
+
+jobs:
+  build-and-test:
+    name: Build and test
+
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [ Release, Debug ]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Configure
+      run: cmake -B _build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+
+    - name: Build
+      run: cmake --build _build --config ${{ matrix.build_type }}
+
+    - name: Test
+      run: ctest --output-on-failure --test-dir _build --build-config ${{ matrix.build_type }}


### PR DESCRIPTION
Add CMake based CI workflow to build and test for Release and Debug on Ubuntu, Windows, MacOS.