### PR TITLE
CMake config installation fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,24 +44,32 @@ install(
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 include(CMakePackageConfigHelpers)
-write_basic_package_version_file(
-  "${PROJECT_NAME}ConfigVersion.cmake"
-  VERSION ${PROJECT_VERSION}
-  COMPATIBILITY SameMajorVersion)
+if(${CMAKE_VERSION} VERSION_LESS 3.14)
+  write_basic_package_version_file(
+    "${PROJECT_NAME}ConfigVersion.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion)
+else()
+  write_basic_package_version_file(
+    "${PROJECT_NAME}ConfigVersion.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+    ARCH_INDEPENDENT)
+endif()
 
 configure_package_config_file(
   "${PROJECT_SOURCE_DIR}/cmake/Config.cmake.in"
   "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake" INSTALL_DESTINATION
-  ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake)
+  ${CMAKE_INSTALL_DATAROOTDIR}/cmake/${PROJECT_NAME})
 
 install(
   EXPORT ${PROJECT_NAME}_Targets
   FILE ${PROJECT_NAME}Targets.cmake
   NAMESPACE ${PROJECT_NAME}::
-  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake)
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/cmake/${PROJECT_NAME})
 
 install(FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
               "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
-        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake)
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/cmake/${PROJECT_NAME})
 
-install(FILES "${PROJECT_SOURCE_DIR}/mdns.h" DESTINATION include)
+install(FILES "${PROJECT_SOURCE_DIR}/mdns.h" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})


### PR DESCRIPTION
Changes:
- Fixed incorrect CMake config destination path. Current: `/usr/share/mdns/cmake/`, the correct one - `/usr/share/cmake/mdns/`.
- Switched to `CMAKE_INSTALL_INCLUDEDIR` for header installation.
- Explicitly marked generated CMake configs as architecture independent.