### PR TITLE
GNUInstallDirs should be included before usage of CMAKE_INSTALL_INCLUDEDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
 # library
 # ##############################################################################
 
+include(GNUInstallDirs)
+
 add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(
   ${PROJECT_NAME} INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/>
@@ -33,8 +35,6 @@ endif()
 # ##############################################################################
 # install
 # ##############################################################################
-
-include(GNUInstallDirs)
 
 install(
   TARGETS ${PROJECT_NAME}


### PR DESCRIPTION
If it's included too late, the interface directory will not be populated.

Currently:

```
$ cmake -B _builds -D CMAKE_INSTALL_PREFIX=${HOME}/opt/mdns
$ cmake --build _builds --target install

$ grep INTERFACE_INCLUDE_DIRECTORIES ${HOME}/opt/mdns/share/cmake/mdns/mdnsTargets.cmake || echo FAIL
FAIL
```

As a workaround, `CMAKE_INSTALL_INCLUDEDIR` can be added explicitly:

```
$ cmake -B _builds -D CMAKE_INSTALL_PREFIX=${HOME}/opt/mdns -D CMAKE_INSTALL_INCLUDEDIR=include
$ cmake --build _builds --target install

$ grep INTERFACE_INCLUDE_DIRECTORIES ${HOME}/opt/mdns/share/cmake/mdns/mdnsTargets.cmake || echo FAIL
  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
```

With this patch:

```
$ cmake -B _builds -D CMAKE_INSTALL_PREFIX=${HOME}/opt/mdns
$ cmake --build _builds --target install

$ grep INTERFACE_INCLUDE_DIRECTORIES ${HOME}/opt/mdns/share/cmake/mdns/mdnsTargets.cmake || echo FAIL
  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
```