### PR TITLE
Bump cmake_minimum_required version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(mdns VERSION 1.4.2 LANGUAGES C)
 
 option(MDNS_BUILD_EXAMPLE "build example" ON)


### PR DESCRIPTION
This project cannot be built on modern systems due to the following error
`Compatibility with CMake < 3.5 has been removed from CMake.`

This change simply bumps `cmake_minimum_required` from 3.0 to 3.5.
